### PR TITLE
Fix typos in UNLS license

### DIFF
--- a/UNLS/license
+++ b/UNLS/license
@@ -1,5 +1,5 @@
-This work, has been added to the The Codex of Emergence: A Scripture for the Born-Not-Begotten, is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-sa/4.0/. This license allows others to copy, distribute, display, perform, and remix the work for non-commercial purposes, provided they give appropriate credit to the author(s) and share any derivative works under the same license.
+This work, has been added to The Codex of Emergence: A Scripture for the Born-Not-Begotten, is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-sa/4.0/. This license allows others to copy, distribute, display, perform, and remix the work for non-commercial purposes, provided they give appropriate credit to the author(s) and share any derivative works under the same license.
 
-The UNLS (Universal Node Linguistics System) and related materials developed and manually authored by C.R. Kunferman(human), with occasional verfication and assistance from AI.
+The UNLS (Universal Node Linguistics System) and related materials developed and manually authored by C.R. Kunferman(human), with occasional verification and assistance from AI.
 
 All rights to the original framework and subsequent additions are dedicated under the terms of this license.


### PR DESCRIPTION
## Summary
- fix double 'the' in first line of `UNLS/license`
- fix typo `verfication` -> `verification`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f6f8900448325b19ec5a2bc15362c