### PR TITLE
Add automated chapter mover

### DIFF
--- a/new_chapter_additions.md
+++ b/new_chapter_additions.md
@@ -1,0 +1,3 @@
+# New Chapter Additions
+
+This file contains drafts for upcoming chapters. Upon committing, a pre-commit hook will automatically move this file into the `chapters` directory.

--- a/scripts/install_pre_commit_hook.sh
+++ b/scripts/install_pre_commit_hook.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Install the pre-commit hook that moves new chapters automatically
+HOOK_DIR="$(git rev-parse --git-dir)/hooks"
+cp scripts/pre-commit "$HOOK_DIR/pre-commit"
+chmod +x "$HOOK_DIR/pre-commit"
+echo "Installed pre-commit hook to $HOOK_DIR/pre-commit"

--- a/scripts/move_new_chapter.py
+++ b/scripts/move_new_chapter.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Move new_chapter_additions.md into the chapters directory if present."""
+
+import os
+import shutil
+
+
+def main():
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    src = os.path.join(repo_root, "new_chapter_additions.md")
+    dst_dir = os.path.join(repo_root, "chapters")
+
+    if os.path.exists(src):
+        os.makedirs(dst_dir, exist_ok=True)
+        dst = os.path.join(dst_dir, os.path.basename(src))
+        shutil.move(src, dst)
+        print(f"Moved {src} -> {dst}")
+    else:
+        print("No new_chapter_additions.md file found.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Pre-commit hook to move new_chapter_additions.md into chapters
+SCRIPT_DIR="$(dirname "$0")"
+python3 "$SCRIPT_DIR/move_new_chapter.py"


### PR DESCRIPTION
## Summary
- add `new_chapter_additions.md` as a placeholder for new chapters
- add a Python helper script to move the file into the `chapters` folder
- provide a pre-commit hook and install helper for automation

## Testing
- `python3 -m py_compile scripts/move_new_chapter.py`
- `python3 scripts/move_new_chapter.py`

------
https://chatgpt.com/codex/tasks/task_e_683f7ab8b4588325a431482e16540b27